### PR TITLE
configure: drop color-tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.60)
 AC_INIT(connman-ui, 0.1)
 
-AM_INIT_AUTOMAKE([foreign subdir-objects color-tests])
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 


### PR DESCRIPTION
Recent autotools have it enabled by default, older autotools might not support it.

(In response of a Sabayon maintainer request)
