### PR TITLE
lib: initialize dbus errors properly

### DIFF
--- a/lib/service.c
+++ b/lib/service.c
@@ -1028,6 +1028,7 @@ static void set_property_cb(DBusPendingCall *pending, void *user_data)
 	if (reply == NULL)
 		return;
 
+	dbus_error_init(&error);
 	if (dbus_set_error_from_message(&error, reply) == FALSE)
 		goto done;
 

--- a/lib/technology.c
+++ b/lib/technology.c
@@ -426,6 +426,7 @@ static void set_property_cb(DBusPendingCall *pending, void *user_data)
 	if (reply == NULL)
 		return;
 
+	dbus_error_init(&error);
 	if (dbus_set_error_from_message(&error, reply) == FALSE)
 		goto done;
 


### PR DESCRIPTION
Fix dbus assertion error when enabling or disabling a technology.

Same style as in lib/interface.c.
