### PR TITLE
Don't choose a status icon size.

### DIFF
--- a/src/connman-ui-gtk.h
+++ b/src/connman-ui-gtk.h
@@ -46,6 +46,8 @@ void cui_theme_get_type_icone_and_info(const char *type,
 					GdkPixbuf **image, const char **info);
 void cui_theme_get_signal_icone_and_info(uint8_t signal_strength,
 					GdkPixbuf **image, const char **info);
+void cui_theme_get_state_icon_name_and_info(enum connman_state state,
+					const char **icon_name, const char **info);
 void cui_theme_get_state_icone_and_info(enum connman_state state,
 					GdkPixbuf **image, const char **info);
 void cui_theme_get_tethering_icone_and_info(GdkPixbuf **image,

--- a/src/theme.c
+++ b/src/theme.c
@@ -88,42 +88,51 @@ void cui_theme_get_signal_icone_and_info(uint8_t signal_strength,
 
 }
 
-void cui_theme_get_state_icone_and_info(enum connman_state state,
-					GdkPixbuf **image, const char **info)
+void cui_theme_get_state_icon_name_and_info(enum connman_state state,
+					const char **icon_name, const char **info)
 {
 	const char *nfo = NULL;
-	GdkPixbuf *img = NULL;
+	const char *img = NULL;
 
 
 	switch (state) {
 	case CONNMAN_STATE_UNKNOWN:
-		img = gtk_icon_theme_load_icon(icon_theme,
-					"network-offline-symbolic", 24, 0, NULL);
+		img = "network-offline-symbolic";
 		nfo = _("Connman is not running");
 		break;
 	case CONNMAN_STATE_READY:
-		img = gtk_icon_theme_load_icon(icon_theme,
-					"network-idle-symbolic", 24, 0, NULL);
+		img = "network-idle-symbolic";
 		nfo = _("Connected");
 		break;
 	case CONNMAN_STATE_ONLINE:
-		img = gtk_icon_theme_load_icon(icon_theme,
-					"network-transmit-receive-symbolic", 24, 0, NULL);
+		img = "network-transmit-receive-symbolic";
 		nfo = _("Online");
 		break;
 	default:
-		img = gtk_icon_theme_load_icon(icon_theme,
-					"network-offline-symbolic", 24, 0, NULL);
+		img = "network-offline-symbolic";
 		nfo = _("Disconnected");
 
 		break;
 	}
 
-	if (image != NULL)
-		*image = img;
+	if (icon_name != NULL)
+		*icon_name = img;
 
 	if (info != NULL)
 		*info = nfo;
+}
+
+void cui_theme_get_state_icone_and_info(enum connman_state state,
+					GdkPixbuf **image, const char **info)
+{
+	const char *icon_name = NULL;
+	GdkPixbuf *img = NULL;
+	cui_theme_get_state_icon_name_and_info(state, &icon_name, info);
+	img = gtk_icon_theme_load_icon(icon_theme,
+				icon_name, 24, 0, NULL);
+
+	if (image != NULL)
+		*image = img;
 }
 
 void cui_load_theme(void)

--- a/src/tray.c
+++ b/src/tray.c
@@ -32,14 +32,14 @@ static int right_menu_handler_id = 0;
 void cui_trayicon_update_icon(void)
 {
 	enum connman_state state;
-	GdkPixbuf *image = NULL;
+	const char *icon = NULL;
 	const char *info = NULL;
 
 	state = connman_manager_get_state();
 
-	cui_theme_get_state_icone_and_info(state, &image, &info);
+	cui_theme_get_state_icon_name_and_info(state, &icon, &info);
 
-	gtk_status_icon_set_from_pixbuf(cui_trayicon, image);
+	gtk_status_icon_set_from_icon_name(cui_trayicon, icon);
 
 	gtk_status_icon_set_tooltip_text(cui_trayicon, info);
 	gtk_status_icon_set_visible(cui_trayicon, TRUE);


### PR DESCRIPTION
gtk_status_icon_set_from_pixbuf doesn't appear to check the width or
height of the GdkPixbuf, so it runs off the end of the pixbuf if your
system tray is configured to display icons at any size larger than 24.

Work around this by using gtk_status_icon_set_from_icon_name.

This is what I see with xfce4-panel's tray using 48x48 icons:
![image](https://user-images.githubusercontent.com/380280/40891646-1673db68-674f-11e8-8389-869dc5af76d0.png)
In "before", you get two copies of the icon, the second missing its first row—which looks like it's wrapping to the next row when it runs off the end of a row. Sometimes the rows past the 24th show me noise from other memory. And I still don't know why the "after" icon is darker.